### PR TITLE
add calendars for FRAM

### DIFF
--- a/fram_school_product_and_details.xml
+++ b/fram_school_product_and_details.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.11:NO-NeTEx-fares:0.9">
+  <!--
+
+    IMPORTANT
+    =========
+
+    The master for this XML file is in the AtB-AS repository here:
+    https://github.com/AtB-AS/netex-data/blob/main/nfk_school_product_and_details.xml
+
+  -->
+  <PublicationTimestamp>2020-09-01T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ABT-REFERENCEDATA</ParticipantRef>
+  <dataObjects>
+
+    <!-- FRAM 2023-2024 (default) -->
+    <ServiceCalendarFrame version="1" id="MOR:ServiceCalendarFrame:SchoolDayFRAM2023-2024">
+      <Name lang="eng">School year calendar for FRAM</Name>
+      <ServiceCalendar id="MOR:ServiceCalendar:SchoolDayFRAM2023-2024" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="MOR:FareDayType:SchoolDayFRAM2023-2024">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="MOR:UicOperatingPeriod:SchoolDayFRAM2023-2024">
+            <FromDate>2023-08-21T00:00:00</FromDate> <!-- 21st Aug 2023 till 21st June 2024 -->
+            <!-- Only necessary to validate that enough validity bits are present -->
+            <ToDate>2024-06-21T00:00:00</ToDate>
+            <ValidDayBits>
+              1111100<!-- Week 34 -->
+              1111100<!-- Week 35 -->
+              1111100<!-- Week 36 -->
+              1111100<!-- Week 37 -->
+              1111100<!-- Week 38 -->
+              1111100<!-- Week 39 -->
+              1111100<!-- Week 40 -->
+              0000000<!-- Week 41 - Autumn (Høstferie) vacation -->
+              1111100<!-- Week 42 -->
+              1111100<!-- Week 43 -->
+              1111100<!-- Week 44 -->
+              1111100<!-- Week 45 -->
+              1111100<!-- Week 46 -->
+              1111100<!-- Week 47 -->
+              1111100<!-- Week 48 -->
+              1111100<!-- Week 49 -->
+              1111100<!-- Week 50 -->
+              1110000<!-- Week 51 - Siste dag før jul 20.desember -->
+              0000000<!-- Week 52 - Christmas vacation -->
+              0011100<!-- Week 1 - Christmas vacation - Skolestart 3.jan. -->
+              1111100<!-- Week 2 -->
+              1111100<!-- Week 3 -->
+              1111100<!-- Week 4 -->
+              1111100<!-- Week 5 -->
+              1111100<!-- Week 6 -->
+              1111100<!-- Week 7 -->
+              0000000<!-- Week 8 - Winter vacation: 19 Feb - 23 Feb -->
+              1111100<!-- Week 9  -->
+              1111100<!-- Week 10 -->
+              1111100<!-- Week 11 -->
+              1111100<!-- Week 12 -->
+              0000000<!-- Week 13 - Easter -->
+              0111100<!-- Week 14 - Easter -->
+              1111100<!-- Week 15 -->
+              1111100<!-- Week 16 -->
+              1111100<!-- Week 17 -->
+              1101100<!-- Week 18 - Off. høgtidsdag: 1 May -->
+              1110000<!-- Week 19 - Ascension: 9 May, Elevfri: 10 May -->
+              1111000<!-- Week 20 - Independence day: 17 May -->
+              0111100<!-- Week 21 - 2. pinsedag: 20 May -->
+              1111100<!-- Week 22 -->
+              1111100<!-- Week 23 -->
+              1111100<!-- Week 24 -->
+              11111<!-- Week 25 -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="MOR:DayTypeAssignment:SchoolDayFRAM2023-2024" order="1">
+            <OperatingPeriodRef ref="MOR:UicOperatingPeriod:SchoolDayFRAM2023-2024"/>
+            <DayTypeRef version="1" ref="MOR:FareDayType:SchoolDayFRAM2023-2024"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
+
+    <!-- FRAM kommune: Emblem skule 2023-2024 -->
+    <ServiceCalendarFrame version="1" id="MOR:ServiceCalendarFrame:SchoolDayEmblemSkule2023-2024">
+      <Name lang="eng">School year calendar for Emblem skule</Name>
+      <ServiceCalendar id="MOR:ServiceCalendar:SchoolDayEmblemSkule2023-2024" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="MOR:FareDayType:SchoolDayEmblemSkule2023-2024">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="MOR:UicOperatingPeriod:SchoolDayEmblemSkule2023-2024">
+            <FromDate>2023-08-21T00:00:00</FromDate> <!-- 21st Aug 2023 till 21st June 2024 -->
+            <!-- Only necessary to validate that enough validity bits are present -->
+            <ToDate>2024-06-21T00:00:00</ToDate>
+            <ValidDayBits>
+              1111100<!-- Week 34 -->
+              1111100<!-- Week 35 -->
+              1111100<!-- Week 36 -->
+              1111100<!-- Week 37 -->
+              1111100<!-- Week 38 -->
+              1111100<!-- Week 39 -->
+              1111100<!-- Week 40 -->
+              0000000<!-- Week 41 - Autumn (Høstferie) vacation -->
+              1111100<!-- Week 42 -->
+              1111100<!-- Week 43 -->
+              1111100<!-- Week 44 -->
+              1111100<!-- Week 45 -->
+              1111100<!-- Week 46 -->
+              1111100<!-- Week 47 -->
+              1111100<!-- Week 48 -->
+              1111100<!-- Week 49 -->
+              1111100<!-- Week 50 -->
+              1110000<!-- Week 51 - Siste dag før jul 20.desember -->
+              0000000<!-- Week 52 - Christmas vacation -->
+              0011100<!-- Week 1 - Christmas vacation - Skolestart 3.jan. -->
+              1111100<!-- Week 2 -->
+              1111100<!-- Week 3 -->
+              1111100<!-- Week 4 -->
+              1111100<!-- Week 5 -->
+              1111100<!-- Week 6 -->
+              1111100<!-- Week 7 -->
+              0000000<!-- Week 8 - Winter vacation: 19 Feb - 23 Feb -->
+              1111100<!-- Week 9  -->
+              1111100<!-- Week 10 -->
+              1111100<!-- Week 11 -->
+              1111100<!-- Week 12 -->
+              0000000<!-- Week 13 - Easter -->
+              0111100<!-- Week 14 - Easter -->
+              1111100<!-- Week 15 -->
+              1111100<!-- Week 16 -->
+              1111100<!-- Week 17 -->
+              1101100<!-- Week 18 - Off. høgtidsdag: 1 May -->
+              1110000<!-- Week 19 - Ascension: 9 May, Elevfri: 10 May -->
+              1111000<!-- Week 20 - Independence day: 17 May -->
+              0111100<!-- Week 21 - 2. pinsedag: 20 May -->
+              1111100<!-- Week 22 -->
+              1111100<!-- Week 23 -->
+              1111100<!-- Week 24 -->
+              11111<!-- Week 25 -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="MOR:DayTypeAssignment:SchoolDayEmblemSkule2023-2024" order="1">
+            <OperatingPeriodRef ref="MOR:UicOperatingPeriod:SchoolDayEmblemSkule2023-2024"/>
+            <DayTypeRef version="1" ref="MOR:FareDayType:SchoolDayEmblemSkule2023-2024"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
+
+  </dataObjects>
+</PublicationDelivery>

--- a/fram_school_product_and_details.xml
+++ b/fram_school_product_and_details.xml
@@ -13,12 +13,12 @@
   <ParticipantRef>ABT-REFERENCEDATA</ParticipantRef>
   <dataObjects>
 
-    <!-- FRAM 2023-2024 (default) -->
-    <ServiceCalendarFrame version="1" id="MOR:ServiceCalendarFrame:SchoolDayFRAM2023-2024">
-      <Name lang="eng">School year calendar for FRAM</Name>
-      <ServiceCalendar id="MOR:ServiceCalendar:SchoolDayFRAM2023-2024" version="1">
+    <!-- MRFK 2023-2024 (default) -->
+    <ServiceCalendarFrame version="1" id="MOR:ServiceCalendarFrame:SchoolDayMRFK2023-2024">
+      <Name lang="eng">School year calendar for MRFK</Name>
+      <ServiceCalendar id="MOR:ServiceCalendar:SchoolDayMRFK2023-2024" version="1">
         <dayTypes>
-          <FareDayType version="1" id="MOR:FareDayType:SchoolDayFRAM2023-2024">
+          <FareDayType version="1" id="MOR:FareDayType:SchoolDayMRFK2023-2024">
             <properties>
               <PropertyOfDay>
                 <HolidayTypes>SchoolDay</HolidayTypes>
@@ -27,7 +27,7 @@
           </FareDayType>
         </dayTypes>
         <operatingPeriods>
-          <UicOperatingPeriod version="1" id="MOR:UicOperatingPeriod:SchoolDayFRAM2023-2024">
+          <UicOperatingPeriod version="1" id="MOR:UicOperatingPeriod:SchoolDayMRFK2023-2024">
             <FromDate>2023-08-21T00:00:00</FromDate> <!-- 21st Aug 2023 till 21st June 2024 -->
             <!-- Only necessary to validate that enough validity bits are present -->
             <ToDate>2024-06-21T00:00:00</ToDate>
@@ -80,15 +80,15 @@
           </UicOperatingPeriod>
         </operatingPeriods>
         <dayTypeAssignments>
-          <DayTypeAssignment version="1" id="MOR:DayTypeAssignment:SchoolDayFRAM2023-2024" order="1">
-            <OperatingPeriodRef ref="MOR:UicOperatingPeriod:SchoolDayFRAM2023-2024"/>
-            <DayTypeRef version="1" ref="MOR:FareDayType:SchoolDayFRAM2023-2024"/>
+          <DayTypeAssignment version="1" id="MOR:DayTypeAssignment:SchoolDayMRFK2023-2024" order="1">
+            <OperatingPeriodRef ref="MOR:UicOperatingPeriod:SchoolDayMRFK2023-2024"/>
+            <DayTypeRef version="1" ref="MOR:FareDayType:SchoolDayMRFK2023-2024"/>
           </DayTypeAssignment>
         </dayTypeAssignments>
       </ServiceCalendar>
     </ServiceCalendarFrame>
 
-    <!-- FRAM kommune: Emblem skule 2023-2024 -->
+    <!-- FRAM Emblem skule 2023-2024 -->
     <ServiceCalendarFrame version="1" id="MOR:ServiceCalendarFrame:SchoolDayEmblemSkule2023-2024">
       <Name lang="eng">School year calendar for Emblem skule</Name>
       <ServiceCalendar id="MOR:ServiceCalendar:SchoolDayEmblemSkule2023-2024" version="1">


### PR DESCRIPTION
https://github.com/AtB-AS/team-platform/issues/441

I was given two calendars one which is the default for everyone and one which is for three students of Emblem skule. 
Even though they are exactly same, they have been registered as two different calendars at MRFK, so we also add them separately.

- [ ] Once added at Entur, should be added in the DB.