### PR TITLE
School calendars 2026/2027 — VKT and NFK

### DIFF
--- a/nfk_school_product_and_details.xml
+++ b/nfk_school_product_and_details.xml
@@ -883,5 +883,82 @@
         </dayTypeAssignments>
       </ServiceCalendar>
     </ServiceCalendarFrame>
+
+    <!-- ######## 2026/2027 ######## -->
+
+    <!-- Nordland kommune 2026-2027 (default) -->
+    <ServiceCalendarFrame version="1" id="NOR:ServiceCalendarFrame:SchoolDayNFK2026-2027">
+      <Name lang="eng">School year calendar for Nordland kommune</Name>
+      <ServiceCalendar id="NOR:ServiceCalendar:SchoolDayNFK2026-2027" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="NOR:FareDayType:SchoolDayNFK2026-2027">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="NOR:UicOperatingPeriod:SchoolDayNFK2026-2027">
+            <FromDate>2026-08-10T00:00:00</FromDate>
+            <ToDate>2027-06-20T23:59:59</ToDate>
+            <ValidDayBits>
+              0001100 <!-- Week 33 - Summer vacation - school starts 13 August -->
+              1111100 <!-- Week 34 -->
+              1111100 <!-- Week 35 -->
+              1111100 <!-- Week 36 -->
+              1111100 <!-- Week 37 -->
+              1111100 <!-- Week 38 -->
+              1111100 <!-- Week 39 -->
+              0000000 <!-- Week 40 - Autumn vacation -->
+              1111100 <!-- Week 41 -->
+              1111100 <!-- Week 42 -->
+              1111100 <!-- Week 43 -->
+              1111100 <!-- Week 44 -->
+              1111100 <!-- Week 45 -->
+              1111100 <!-- Week 46 -->
+              1111000 <!-- Week 47 - Day off 20 November -->
+              1111100 <!-- Week 48 -->
+              1111100 <!-- Week 49 -->
+              1111100 <!-- Week 50 -->
+              1111100 <!-- Week 51 -->
+              0000000 <!-- Week 52 - Christmas vacation -->
+              0000000 <!-- Week 53 - Christmas vacation -->
+              1111100 <!-- Week 1 -->
+              1111100 <!-- Week 2 -->
+              1111100 <!-- Week 3 -->
+              1111100 <!-- Week 4 -->
+              1111100 <!-- Week 5 -->
+              1111100 <!-- Week 6 -->
+              1111100 <!-- Week 7 -->
+              0000000 <!-- Week 8 - Winter vacation -->
+              1111100 <!-- Week 9 -->
+              1111100 <!-- Week 10 -->
+              1111100 <!-- Week 11 -->
+              0000000 <!-- Week 12 - Easter -->
+              0011100 <!-- Week 13 - Easter -->
+              1111100 <!-- Week 14 -->
+              1111100 <!-- Week 15 -->
+              1111100 <!-- Week 16 -->
+              1111100 <!-- Week 17 -->
+              1110000 <!-- Week 18 - Ascension + day off 7 May -->
+              1111100 <!-- Week 19 -->
+              0111100 <!-- Week 20 - May 17th -->
+              1111100 <!-- Week 21 -->
+              1111100 <!-- Week 22 -->
+              1111100 <!-- Week 23 -->
+              1111000 <!-- Week 24 - Last school day 17 June -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="NOR:DayTypeAssignment:SchoolDayNFK2026-2027" order="1">
+            <OperatingPeriodRef ref="NOR:UicOperatingPeriod:SchoolDayNFK2026-2027"/>
+            <DayTypeRef version="1" ref="NOR:FareDayType:SchoolDayNFK2026-2027"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
   </dataObjects>
 </PublicationDelivery>

--- a/vkt_school_product_and_details.xml
+++ b/vkt_school_product_and_details.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.11:NO-NeTEx-fares:0.9">
+  <!--
+
+    IMPORTANT
+    =========
+
+    The master for this XML file is in the AtB-AS repository here:
+    https://github.com/AtB-AS/netex-data/blob/main/vkt_school_product_and_details.xml
+
+  -->
+  <PublicationTimestamp>2020-09-01T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ABT-REFERENCEDATA</ParticipantRef>
+  <dataObjects>
+
+    <!-- ######## 2026/2027 ######## -->
+
+    <!-- Vestfold fylke 2026-2027 (default) -->
+    <ServiceCalendarFrame version="1" id="VKT:ServiceCalendarFrame:SchoolDayVKT2026-2027">
+      <Name lang="eng">School year calendar for Vestfold</Name>
+      <ServiceCalendar id="VKT:ServiceCalendar:SchoolDayVKT2026-2027" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="VKT:FareDayType:SchoolDayVKT2026-2027">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="VKT:UicOperatingPeriod:SchoolDayVKT2026-2027">
+            <FromDate>2026-08-17T00:00:00</FromDate>
+            <ToDate>2027-06-20T23:59:59</ToDate>
+            <ValidDayBits>
+              1111100 <!-- Week 34 - School starts 17 August -->
+              1111100 <!-- Week 35 -->
+              1111100 <!-- Week 36 -->
+              1111100 <!-- Week 37 -->
+              1111100 <!-- Week 38 -->
+              1111100 <!-- Week 39 -->
+              1111100 <!-- Week 40 -->
+              0000000 <!-- Week 41 - Autumn vacation -->
+              1111100 <!-- Week 42 -->
+              1111100 <!-- Week 43 -->
+              1111100 <!-- Week 44 -->
+              1111100 <!-- Week 45 -->
+              1111100 <!-- Week 46 -->
+              1111100 <!-- Week 47 -->
+              1111100 <!-- Week 48 -->
+              1111100 <!-- Week 49 -->
+              1111100 <!-- Week 50 -->
+              1111100 <!-- Week 51 -->
+              0000000 <!-- Week 52 - Christmas vacation -->
+              0000000 <!-- Week 53 - Christmas vacation -->
+              0111100 <!-- Week 1 - Christmas vacation - school resumes 5 January -->
+              1111100 <!-- Week 2 -->
+              1111100 <!-- Week 3 -->
+              1111100 <!-- Week 4 -->
+              1111100 <!-- Week 5 -->
+              1111100 <!-- Week 6 -->
+              1111100 <!-- Week 7 -->
+              0000000 <!-- Week 8 - Winter vacation -->
+              1111100 <!-- Week 9 -->
+              1111100 <!-- Week 10 -->
+              1111100 <!-- Week 11 -->
+              0000000 <!-- Week 12 - Easter -->
+              0111100 <!-- Week 13 - Easter Monday -->
+              1111100 <!-- Week 14 -->
+              1111100 <!-- Week 15 -->
+              1111100 <!-- Week 16 -->
+              1111100 <!-- Week 17 -->
+              1110000 <!-- Week 18 - Ascension + day off 7 May -->
+              1111100 <!-- Week 19 -->
+              0111100 <!-- Week 20 - May 17th -->
+              1111100 <!-- Week 21 -->
+              1111100 <!-- Week 22 -->
+              1111100 <!-- Week 23 -->
+              1111100 <!-- Week 24 - Last school day 18 June -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="VKT:DayTypeAssignment:SchoolDayVKT2026-2027" order="1">
+            <OperatingPeriodRef ref="VKT:UicOperatingPeriod:SchoolDayVKT2026-2027"/>
+            <DayTypeRef version="1" ref="VKT:FareDayType:SchoolDayVKT2026-2027"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
+  </dataObjects>
+</PublicationDelivery>


### PR DESCRIPTION
Adds school-year **2026/2027** calendars for two tenants. Both are the county-wide common calendar (felles skolerute), 190 school days each, taken from the source files provided by each county.

## VKT (Vestfold) — new file
New file `vkt_school_product_and_details.xml`, codespace `VKT:`. "Felles skolerute for kommunene og de videregående skolene i Vestfold."

| | |
|---|---|
| First school day | Mon 17 Aug 2026 |
| Autumn break | Week 41 (5–9 Oct) |
| Christmas | Last day Fri 18 Dec → resumes Tue 5 Jan |
| Winter break | Week 8 (22–26 Feb) |
| Easter | Mon 22 Mar – Mon 29 Mar (back Tue 30) |
| Free days | 6 May (Ascension), 7 May, 17 May |
| Last school day | Fri 18 Jun 2027 |
| Operating period | 2026-08-17 → 2027-06-20 |

## NFK (Nordland) — appended to existing file
New `SchoolDayNFK2026-2027` frame in `nfk_school_product_and_details.xml` (purely additive; existing frames untouched).

| | |
|---|---|
| First school day | Thu 13 Aug 2026 |
| Autumn break | 28 Sep – 2 Oct |
| Free day (elevfri) | 20 Nov |
| Christmas | Last day Fri 18 Dec → resumes Mon 4 Jan |
| Winter break | 22–26 Feb |
| Easter | 22–30 Mar (back Wed 31) |
| Free day (elevfri) | 7 May |
| Last school day | Thu 17 Jun 2027 |
| Operating period | 2026-08-10 → 2027-06-20 |

## Validation
Both calendars were checked programmatically:
- `ValidDayBits` count equals the inclusive `FromDate`→`ToDate` day span (full Mon–Sun weeks, matching the existing NFK convention).
- No school day falls on a weekend or a Norwegian public holiday.
- ISO week-number comments match the real weeks — including the **53-week ISO 2026** (week 53 = 28 Dec – 3 Jan) and the coincidence of **17 May 2027 = Constitution Day + Whit Monday**.
- Per-month school-day totals match the source documents exactly (both sum to 190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)