### PR TITLE
School calendars 2026/2027 — AtB

### DIFF
--- a/atb_school_product_and_details.xml
+++ b/atb_school_product_and_details.xml
@@ -2857,5 +2857,382 @@
         </dayTypeAssignments>
       </ServiceCalendar>
     </ServiceCalendarFrame>
+
+    <!-- ######## 2026/2027 ######## -->
+
+    <!-- Trondheim kommune 2026-2027 -->
+    <ServiceCalendarFrame version="1" id="ATB:ServiceCalendarFrame:SchoolDayTrondheim2026-2027">
+      <Name lang="eng">School year calendar for Trondheim Kommune 2026-2027</Name>
+      <ServiceCalendar id="ATB:ServiceCalendar:SchoolDayTrondheim2026-2027" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="ATB:FareDayType:SchoolDayTrondheim2026-2027">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="ATB:UicOperatingPeriod:SchoolDayTrondheim2026-2027">
+            <FromDate>2026-08-10T00:00:00</FromDate>
+            <ToDate>2027-06-20T23:59:59</ToDate>
+            <ValidDayBits>
+              0000000 <!-- Week 33 - Summer vacation - school starts 17 August -->
+              1111100 <!-- Week 34 -->
+              1111100 <!-- Week 35 -->
+              1111100 <!-- Week 36 -->
+              1111100 <!-- Week 37 -->
+              1111100 <!-- Week 38 -->
+              1111100 <!-- Week 39 -->
+              1111100 <!-- Week 40 -->
+              0000000 <!-- Week 41 - Autumn vacation -->
+              1111100 <!-- Week 42 -->
+              1111100 <!-- Week 43 -->
+              1111100 <!-- Week 44 -->
+              1111100 <!-- Week 45 -->
+              1111100 <!-- Week 46 -->
+              1111100 <!-- Week 47 -->
+              1111100 <!-- Week 48 -->
+              1111100 <!-- Week 49 -->
+              1111100 <!-- Week 50 -->
+              1111100 <!-- Week 51 -->
+              0000000 <!-- Week 52 - Christmas vacation -->
+              0000000 <!-- Week 53 - Christmas vacation -->
+              1111100 <!-- Week 1 -->
+              1111100 <!-- Week 2 -->
+              1111100 <!-- Week 3 -->
+              1111000 <!-- Week 4 - Day off 29 January -->
+              1111100 <!-- Week 5 -->
+              1111100 <!-- Week 6 -->
+              1111100 <!-- Week 7 -->
+              0000000 <!-- Week 8 - Winter vacation -->
+              1111100 <!-- Week 9 -->
+              1111100 <!-- Week 10 -->
+              1111100 <!-- Week 11 -->
+              0000000 <!-- Week 12 - Easter -->
+              0111100 <!-- Week 13 - Easter -->
+              1111100 <!-- Week 14 -->
+              1111100 <!-- Week 15 -->
+              1111100 <!-- Week 16 -->
+              1111100 <!-- Week 17 -->
+              1110000 <!-- Week 18 - Ascension + day off 7 May -->
+              1111100 <!-- Week 19 -->
+              0111100 <!-- Week 20 - May 17th -->
+              1111100 <!-- Week 21 -->
+              1111100 <!-- Week 22 -->
+              1111100 <!-- Week 23 -->
+              1111100 <!-- Week 24 - Last school day 18 June -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="ATB:DayTypeAssignment:SchoolDayTrondheim2026-2027" order="1">
+            <OperatingPeriodRef ref="ATB:UicOperatingPeriod:SchoolDayTrondheim2026-2027"/>
+            <DayTypeRef version="1" ref="ATB:FareDayType:SchoolDayTrondheim2026-2027"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
+
+    <!-- TRFK - Ramme for VGS 2026-2027 -->
+    <ServiceCalendarFrame version="1" id="ATB:ServiceCalendarFrame:SchoolDayTRFK2026-2027">
+      <Name lang="eng">School year calendar for Trøndelag Fylkeskommune</Name>
+      <ServiceCalendar id="ATB:ServiceCalendar:SchoolDayTRFK2026-2027" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="ATB:FareDayType:SchoolDayTRFK2026-2027">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="ATB:UicOperatingPeriod:SchoolDayTRFK2026-2027">
+            <FromDate>2026-08-10T00:00:00</FromDate>
+            <ToDate>2027-06-20T23:59:59</ToDate>
+            <ValidDayBits>
+              0000000 <!-- Week 33 - Summer vacation - school starts 17 August -->
+              1111100 <!-- Week 34 -->
+              1111100 <!-- Week 35 -->
+              1111100 <!-- Week 36 -->
+              1111100 <!-- Week 37 -->
+              1111100 <!-- Week 38 -->
+              1111100 <!-- Week 39 -->
+              1111100 <!-- Week 40 -->
+              0000000 <!-- Week 41 - Autumn vacation -->
+              1111100 <!-- Week 42 -->
+              1111100 <!-- Week 43 -->
+              1101100 <!-- Week 44 - Day off 28 October -->
+              1111100 <!-- Week 45 -->
+              1111100 <!-- Week 46 -->
+              1111100 <!-- Week 47 -->
+              1111100 <!-- Week 48 -->
+              1111100 <!-- Week 49 -->
+              1111100 <!-- Week 50 -->
+              1111100 <!-- Week 51 -->
+              1100000 <!-- Week 52 - Christmas vacation -->
+              0000000 <!-- Week 53 - Christmas vacation -->
+              0111100 <!-- Week 1 - Christmas vacation -->
+              1111100 <!-- Week 2 -->
+              1111100 <!-- Week 3 -->
+              1111100 <!-- Week 4 -->
+              1111100 <!-- Week 5 -->
+              1111100 <!-- Week 6 -->
+              1111100 <!-- Week 7 -->
+              0000000 <!-- Week 8 - Winter vacation -->
+              1111100 <!-- Week 9 -->
+              1111100 <!-- Week 10 -->
+              1111100 <!-- Week 11 -->
+              0000000 <!-- Week 12 - Easter -->
+              0111100 <!-- Week 13 - Easter -->
+              1111100 <!-- Week 14 -->
+              1111000 <!-- Week 15 - Day off 16 April -->
+              1111100 <!-- Week 16 -->
+              1111100 <!-- Week 17 -->
+              1110000 <!-- Week 18 - Ascension + day off 7 May -->
+              1111100 <!-- Week 19 -->
+              0111100 <!-- Week 20 - May 17th -->
+              1111100 <!-- Week 21 -->
+              1111100 <!-- Week 22 -->
+              1111100 <!-- Week 23 -->
+              1111100 <!-- Week 24 - Last school day 18 June -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="ATB:DayTypeAssignment:SchoolDayTRFK2026-2027" order="1">
+            <OperatingPeriodRef ref="ATB:UicOperatingPeriod:SchoolDayTRFK2026-2027"/>
+            <DayTypeRef version="1" ref="ATB:FareDayType:SchoolDayTRFK2026-2027"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
+
+    <!-- Røros kommune 2026-2027 -->
+    <ServiceCalendarFrame version="1" id="ATB:ServiceCalendarFrame:SchoolDayRoros2026-2027">
+      <Name lang="eng">School year calendar for Røros Kommune</Name>
+      <ServiceCalendar id="ATB:ServiceCalendar:SchoolDayRoros2026-2027" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="ATB:FareDayType:SchoolDayRoros2026-2027">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="ATB:UicOperatingPeriod:SchoolDayRoros2026-2027">
+            <FromDate>2026-08-10T00:00:00</FromDate>
+            <ToDate>2027-06-20T23:59:59</ToDate>
+            <ValidDayBits>
+              0000000 <!-- Week 33 - Summer vacation - school starts 17 August -->
+              1111100 <!-- Week 34 -->
+              1111100 <!-- Week 35 -->
+              1111100 <!-- Week 36 -->
+              1111100 <!-- Week 37 -->
+              1111100 <!-- Week 38 -->
+              1111100 <!-- Week 39 -->
+              1111100 <!-- Week 40 -->
+              0000000 <!-- Week 41 - Autumn vacation -->
+              1111100 <!-- Week 42 -->
+              1111100 <!-- Week 43 -->
+              1101100 <!-- Week 44 - Day off 28 October -->
+              1111100 <!-- Week 45 -->
+              1111100 <!-- Week 46 -->
+              1111100 <!-- Week 47 -->
+              1111100 <!-- Week 48 -->
+              1111100 <!-- Week 49 -->
+              1111100 <!-- Week 50 -->
+              1111100 <!-- Week 51 -->
+              1100000 <!-- Week 52 - Christmas vacation -->
+              0000000 <!-- Week 53 - Christmas vacation -->
+              1111100 <!-- Week 1 -->
+              1111100 <!-- Week 2 -->
+              1111100 <!-- Week 3 -->
+              1111100 <!-- Week 4 -->
+              1111100 <!-- Week 5 -->
+              1111100 <!-- Week 6 -->
+              1111000 <!-- Week 7 - Winter vacation -->
+              0000000 <!-- Week 8 - Winter vacation -->
+              1111100 <!-- Week 9 -->
+              1111100 <!-- Week 10 -->
+              1111100 <!-- Week 11 -->
+              0000000 <!-- Week 12 - Easter -->
+              0111100 <!-- Week 13 - Easter -->
+              1111100 <!-- Week 14 -->
+              1111000 <!-- Week 15 - Day off 16 April -->
+              1111100 <!-- Week 16 -->
+              1111100 <!-- Week 17 -->
+              1110000 <!-- Week 18 - Ascension + day off 7 May -->
+              1111100 <!-- Week 19 -->
+              0111100 <!-- Week 20 - May 17th -->
+              1111100 <!-- Week 21 -->
+              1111100 <!-- Week 22 -->
+              1111100 <!-- Week 23 -->
+              1111100 <!-- Week 24 - Last school day 18 June -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="ATB:DayTypeAssignment:SchoolDayRoros2026-2027" order="1">
+            <OperatingPeriodRef ref="ATB:UicOperatingPeriod:SchoolDayRoros2026-2027"/>
+            <DayTypeRef version="1" ref="ATB:FareDayType:SchoolDayRoros2026-2027"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
+
+    <!-- Lierne kommune 2026-2027 -->
+    <ServiceCalendarFrame version="1" id="ATB:ServiceCalendarFrame:SchoolDayLierne2026-2027">
+      <Name lang="eng">School year calendar for Lierne Kommune</Name>
+      <ServiceCalendar id="ATB:ServiceCalendar:SchoolDayLierne2026-2027" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="ATB:FareDayType:SchoolDayLierne2026-2027">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="ATB:UicOperatingPeriod:SchoolDayLierne2026-2027">
+            <FromDate>2026-08-10T00:00:00</FromDate>
+            <ToDate>2027-06-20T23:59:59</ToDate>
+            <ValidDayBits>
+              0000000 <!-- Week 33 - Summer vacation - school starts 17 August -->
+              1111100 <!-- Week 34 -->
+              1111100 <!-- Week 35 -->
+              1111100 <!-- Week 36 -->
+              1111100 <!-- Week 37 -->
+              1111100 <!-- Week 38 -->
+              1111100 <!-- Week 39 -->
+              1111100 <!-- Week 40 -->
+              0000000 <!-- Week 41 - Autumn vacation -->
+              1111100 <!-- Week 42 -->
+              1111100 <!-- Week 43 -->
+              1101100 <!-- Week 44 - Day off 28 October -->
+              1111100 <!-- Week 45 -->
+              1111100 <!-- Week 46 -->
+              1111100 <!-- Week 47 -->
+              1111100 <!-- Week 48 -->
+              1111100 <!-- Week 49 -->
+              1111100 <!-- Week 50 -->
+              1111100 <!-- Week 51 -->
+              1000000 <!-- Week 52 - Christmas vacation -->
+              0000000 <!-- Week 53 - Christmas vacation -->
+              0111100 <!-- Week 1 - Christmas vacation -->
+              1111100 <!-- Week 2 -->
+              1111100 <!-- Week 3 -->
+              1111100 <!-- Week 4 -->
+              1111100 <!-- Week 5 -->
+              1111100 <!-- Week 6 -->
+              1111100 <!-- Week 7 -->
+              0000000 <!-- Week 8 - Winter vacation -->
+              1111100 <!-- Week 9 -->
+              1111100 <!-- Week 10 -->
+              1111100 <!-- Week 11 -->
+              0000000 <!-- Week 12 - Easter -->
+              0111100 <!-- Week 13 - Easter -->
+              1111100 <!-- Week 14 -->
+              1111100 <!-- Week 15 -->
+              1111100 <!-- Week 16 -->
+              1111100 <!-- Week 17 -->
+              1110000 <!-- Week 18 - Ascension + day off 7 May -->
+              1111100 <!-- Week 19 -->
+              0111100 <!-- Week 20 - May 17th -->
+              1111100 <!-- Week 21 -->
+              1111100 <!-- Week 22 -->
+              1111100 <!-- Week 23 -->
+              1111100 <!-- Week 24 - Last school day 18 June -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="ATB:DayTypeAssignment:SchoolDayLierne2026-2027" order="1">
+            <OperatingPeriodRef ref="ATB:UicOperatingPeriod:SchoolDayLierne2026-2027"/>
+            <DayTypeRef version="1" ref="ATB:FareDayType:SchoolDayLierne2026-2027"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
+
+    <!-- Røyrvik kommune 2026-2027 (new) -->
+    <ServiceCalendarFrame version="1" id="ATB:ServiceCalendarFrame:SchoolDayRoyrvik2026-2027">
+      <Name lang="eng">School year calendar for Røyrvik Kommune</Name>
+      <ServiceCalendar id="ATB:ServiceCalendar:SchoolDayRoyrvik2026-2027" version="1">
+        <dayTypes>
+          <FareDayType version="1" id="ATB:FareDayType:SchoolDayRoyrvik2026-2027">
+            <properties>
+              <PropertyOfDay>
+                <HolidayTypes>SchoolDay</HolidayTypes>
+              </PropertyOfDay>
+            </properties>
+          </FareDayType>
+        </dayTypes>
+        <operatingPeriods>
+          <UicOperatingPeriod version="1" id="ATB:UicOperatingPeriod:SchoolDayRoyrvik2026-2027">
+            <FromDate>2026-08-10T00:00:00</FromDate>
+            <ToDate>2027-06-20T23:59:59</ToDate>
+            <ValidDayBits>
+              0000000 <!-- Week 33 - Summer vacation - school starts 17 August -->
+              1111100 <!-- Week 34 -->
+              1111100 <!-- Week 35 -->
+              1111100 <!-- Week 36 -->
+              1111100 <!-- Week 37 -->
+              1111100 <!-- Week 38 -->
+              1111100 <!-- Week 39 -->
+              1111100 <!-- Week 40 -->
+              0000000 <!-- Week 41 - Autumn vacation -->
+              1111100 <!-- Week 42 -->
+              1111100 <!-- Week 43 -->
+              1101100 <!-- Week 44 - Day off 28 October -->
+              1111100 <!-- Week 45 -->
+              1111100 <!-- Week 46 -->
+              1111100 <!-- Week 47 -->
+              1111100 <!-- Week 48 -->
+              1111100 <!-- Week 49 -->
+              1111100 <!-- Week 50 -->
+              1111100 <!-- Week 51 -->
+              0000000 <!-- Week 52 - Christmas vacation -->
+              0000000 <!-- Week 53 - Christmas vacation -->
+              1111100 <!-- Week 1 -->
+              1111100 <!-- Week 2 -->
+              1111100 <!-- Week 3 -->
+              1111100 <!-- Week 4 -->
+              1111100 <!-- Week 5 -->
+              1111100 <!-- Week 6 -->
+              1111100 <!-- Week 7 -->
+              0000000 <!-- Week 8 - Winter vacation -->
+              1111100 <!-- Week 9 -->
+              1111100 <!-- Week 10 -->
+              1111100 <!-- Week 11 -->
+              0000000 <!-- Week 12 - Easter -->
+              0111100 <!-- Week 13 - Easter -->
+              1111100 <!-- Week 14 -->
+              1111000 <!-- Week 15 - Day off 16 April -->
+              1111100 <!-- Week 16 -->
+              1111100 <!-- Week 17 -->
+              1110000 <!-- Week 18 - Ascension + day off 7 May -->
+              1111100 <!-- Week 19 -->
+              0111100 <!-- Week 20 - May 17th -->
+              1111100 <!-- Week 21 -->
+              1111100 <!-- Week 22 -->
+              1111100 <!-- Week 23 -->
+              1111100 <!-- Week 24 - Last school day 18 June -->
+            </ValidDayBits>
+          </UicOperatingPeriod>
+        </operatingPeriods>
+        <dayTypeAssignments>
+          <DayTypeAssignment version="1" id="ATB:DayTypeAssignment:SchoolDayRoyrvik2026-2027" order="1">
+            <OperatingPeriodRef ref="ATB:UicOperatingPeriod:SchoolDayRoyrvik2026-2027"/>
+            <DayTypeRef version="1" ref="ATB:FareDayType:SchoolDayRoyrvik2026-2027"/>
+          </DayTypeAssignment>
+        </dayTypeAssignments>
+      </ServiceCalendar>
+    </ServiceCalendarFrame>
   </dataObjects>
 </PublicationDelivery>


### PR DESCRIPTION
Adds school-year **2026/2027** calendars to `atb_school_product_and_details.xml` (purely additive — existing frames untouched). Source: *Sammenstilt Skolekalender 2026-2027.xlsx* (the "Oppdatert" sheet), provided by AtB.

Five `ServiceCalendarFrame`s under `ATB:`, all running **2026-08-10 → 2027-06-20** (full Mon–Sun weeks, school starts Mon 17 Aug, last day Fri 18 Jun):

| Tenant | School days | Notes |
|---|:-:|---|
| Trondheim | 190 | |
| TRFK (Ramme for VGS) | 190 | |
| Røros | 190 | |
| Lierne | 190 | |
| **Røyrvik** | 189 | **New tenant this year** |

> **Rennebu** is intentionally not included — it uses the TRFK ramme (its products reference the TRFK calendar), so it needs no separate frame. (The "Rennebu 189 skyssdager" comment in the source sheet was a typo for Røyrvik, which is the 189-day calendar.)

### Shared pattern
Autumn break wk 41 (5–9 Oct) · winter break wk 8 (22–26 Feb) · Easter Mon 22 – Mon 29 Mar · Ascension + squeeze day 6–7 May · 17 May.

### Per-tenant differences (from the source grid)
| Day | TRFK | Trondheim | Lierne | Røros | Røyrvik |
|---|:-:|:-:|:-:|:-:|:-:|
| Wed 28 Oct (planning) | free | school | free | free | free |
| Last day before Christmas | Tue 22 Dec | Fri 18 Dec | Mon 21 Dec | Tue 22 Dec | Fri 18 Dec |
| Back after Christmas | Tue 5 Jan | Mon 4 Jan | Tue 5 Jan | Mon 4 Jan | Mon 4 Jan |
| Fri 29 Jan (planning) | — | free | — | — | — |
| Fri 19 Feb (extends winter) | — | — | — | free | — |
| Fri 16 Apr (planning) | free | — | — | free | free |

### Validation
Bits generated directly from the source grid, then re-parsed from the written XML and checked:
- `ValidDayBits` count = `FromDate`→`ToDate` span (315 bits = 45 weeks) for every tenant.
- Per-tenant school-day totals match the source sheet exactly (incl. Røyrvik 189).
- No school day on a weekend or Norwegian public holiday.
- ISO week-number comments correct, including the **53-week ISO 2026** and **17 May 2027 = Constitution Day + Whit Monday**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)