### PR TITLE
Rename VKT 2026/2027 calendar ids to Grunnskole

### DIFF
--- a/vkt_school_product_and_details.xml
+++ b/vkt_school_product_and_details.xml
@@ -16,11 +16,11 @@
     <!-- ######## 2026/2027 ######## -->
 
     <!-- Vestfold fylke 2026-2027 (default) -->
-    <ServiceCalendarFrame version="1" id="VKT:ServiceCalendarFrame:SchoolDayVKT2026-2027">
+    <ServiceCalendarFrame version="1" id="VKT:ServiceCalendarFrame:Grunnskole2026-2027">
       <Name lang="eng">School year calendar for Vestfold</Name>
-      <ServiceCalendar id="VKT:ServiceCalendar:SchoolDayVKT2026-2027" version="1">
+      <ServiceCalendar id="VKT:ServiceCalendar:Grunnskole2026-2027" version="1">
         <dayTypes>
-          <FareDayType version="1" id="VKT:FareDayType:SchoolDayVKT2026-2027">
+          <FareDayType version="1" id="VKT:FareDayType:Grunnskole2026-2027">
             <properties>
               <PropertyOfDay>
                 <HolidayTypes>SchoolDay</HolidayTypes>
@@ -29,7 +29,7 @@
           </FareDayType>
         </dayTypes>
         <operatingPeriods>
-          <UicOperatingPeriod version="1" id="VKT:UicOperatingPeriod:SchoolDayVKT2026-2027">
+          <UicOperatingPeriod version="1" id="VKT:UicOperatingPeriod:Grunnskole2026-2027">
             <FromDate>2026-08-17T00:00:00</FromDate>
             <ToDate>2027-06-20T23:59:59</ToDate>
             <ValidDayBits>
@@ -81,9 +81,9 @@
           </UicOperatingPeriod>
         </operatingPeriods>
         <dayTypeAssignments>
-          <DayTypeAssignment version="1" id="VKT:DayTypeAssignment:SchoolDayVKT2026-2027" order="1">
-            <OperatingPeriodRef ref="VKT:UicOperatingPeriod:SchoolDayVKT2026-2027"/>
-            <DayTypeRef version="1" ref="VKT:FareDayType:SchoolDayVKT2026-2027"/>
+          <DayTypeAssignment version="1" id="VKT:DayTypeAssignment:Grunnskole2026-2027" order="1">
+            <OperatingPeriodRef ref="VKT:UicOperatingPeriod:Grunnskole2026-2027"/>
+            <DayTypeRef version="1" ref="VKT:FareDayType:Grunnskole2026-2027"/>
           </DayTypeAssignment>
         </dayTypeAssignments>
       </ServiceCalendar>


### PR DESCRIPTION
Small follow-up to #16. Renames **all** the VKT 2026/2027 ids to the **`Grunnskole2026-2027`** stem (replacing the original `SchoolDayVKT2026-2027`), so the day-type name reflects compulsory school — grades 1–10 (barneskole + ungdomsskole), not just primary 1–7:

- `VKT:ServiceCalendarFrame:Grunnskole2026-2027`
- `VKT:ServiceCalendar:Grunnskole2026-2027`
- `VKT:FareDayType:Grunnskole2026-2027` (+ the `DayTypeRef` to it)
- `VKT:UicOperatingPeriod:Grunnskole2026-2027` (+ the `OperatingPeriodRef` to it)
- `VKT:DayTypeAssignment:Grunnskole2026-2027`

Internal references updated alongside their definitions, so both ref pairs still resolve. Calendar data (`FromDate`/`ToDate`/`ValidDayBits`) unchanged; file well-formed (`xmllint`). Codespace stays `VKT:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)